### PR TITLE
Add python backend and responsive chat width

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,18 @@ docker build . -t ghcr.io/yoziru/nextjs-vllm-ui:latest \
 [shadcn-ui](https://ui.shadcn.com/) - UI component built using Radix UI and Tailwind CSS
 
 [shadcn-chat](https://github.com/jakobhoeg/shadcn-chat) - Chat components for NextJS/React projects
+
+## Example Python backend
+
+The repository now includes a simple Flask server under `backend/` that
+mimics an OpenAI compatible `/api/chat` endpoint. It currently echoes back
+the last user message but can be extended to call a vLLM instance.
+
+Run it with:
+
+```bash
+pip install flask
+python backend/server.py
+```
+
+Then point the frontend to `http://localhost:5000/api/chat`.

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,31 @@
+from flask import Flask, request, jsonify
+import time
+
+app = Flask(__name__)
+
+@app.post('/api/chat')
+def chat():
+    data = request.get_json(force=True)
+    messages = data.get('messages', [])
+    # In a real implementation this is where you would query the model
+    # Here we simply echo back the last user message.
+    user_msg = next((m['content'] for m in reversed(messages) if m.get('role') == 'user'), '')
+    content = f"Echo: {user_msg}"
+
+    response = {
+        "id": f"chatcmpl-mock-{int(time.time())}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "gemma-3-27b-it-GPTQ-4b-128g",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop"
+            }
+        ],
+    }
+    return jsonify(response)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -101,7 +101,7 @@ export default function ChatList({ messages, isLoading }: ChatListProps) {
   return (
     <div
       id="scroller"
-      className="w-[800px] overflow-y-scroll overflow-x-hidden h-full justify-center m-auto"
+      className="w-full md:w-[800px] max-w-full overflow-y-scroll overflow-x-hidden h-full justify-center m-auto"
     >
       <div className="px-4 py-2 justify-center text-base md:gap-6 m-auto">
         {messages


### PR DESCRIPTION
## Summary
- add a minimal Flask backend that mimics an OpenAI-style `/api/chat` endpoint
- document how to run the Python backend in the README
- make chat list width responsive so the chat window appears without zooming

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68896320f70c832ca14d5344f3d3df3f